### PR TITLE
support pinout svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ export default () => (
   </board>
 )
 `,
-  "pcb" // or "schematic" for schematic view
+  "pcb" // or "schematic", "3d", or "pinout"
 )
 
 // Returns URL pointing to https://svg.tscircuit.com

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -29,7 +29,7 @@ export function getUncompressedSnippetString(
 
 export function createSvgUrl(
   tscircuitCode: string,
-  svgType: "pcb" | "schematic" | "3d",
+  svgType: "pcb" | "schematic" | "3d" | "pinout",
 ) {
   const base64Data = getCompressedBase64SnippetString(tscircuitCode)
   return `https://svg.tscircuit.com/?svg_type=${svgType}&code=${encodeURIComponent(base64Data)}`

--- a/tests/test3-svg-url.test.ts
+++ b/tests/test3-svg-url.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test"
 import { createSvgUrl } from "lib"
 
-test("create snippets url", () => {
+test("create pcb svg url", () => {
   const url = createSvgUrl(
     `
 export default () => (
@@ -15,5 +15,22 @@ export default () => (
 
   expect(url).toMatchInlineSnapshot(
     `"https://svg.tscircuit.com/?svg_type=pcb&code=H4sIAJsBqGcAAy2NTQ7CIBhE9z3FhFW7KlWXhUO4ckuBClF%2BAp%2FRxHh30Xb3JvMyY185FYKxq3rcCf0AIdF3wLwkVQye3pATbOIhMDjrr472JJvUtGKrr5QKNlBR2ybcGNaUKBcfm89P%2FMAQVWjVeWKo2l3E%2B%2FhB1ssG429tHv%2Bfshu%2BlSYxzJYAAAA%3D"`,
+  )
+})
+
+test("create pinout svg url", () => {
+  const url = createSvgUrl(
+    `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)
+`,
+    "pinout",
+  )
+
+  expect(url).toMatchInlineSnapshot(
+    `"https://svg.tscircuit.com/?svg_type=pinout&code=H4sIAJsBqGcAAy2NTQ7CIBhE9z3FhFW7KlWXhUO4ckuBClF%2BAp%2FRxHh30Xb3JvMyY185FYKxq3rcCf0AIdF3wLwkVQye3pATbOIhMDjrr472JJvUtGKrr5QKNlBR2ybcGNaUKBcfm89P%2FMAQVWjVeWKo2l3E%2B%2FhB1ssG429tHv%2Bfshu%2BlSYxzJYAAAA%3D"`,
   )
 })


### PR DESCRIPTION
This adds support for pinout to createSvgUrl, similar to the existing support for pcb, schematic and 3d. This is useful for embedding pinout diagrams.                         

I've also added a test and updated the documentation. 