### PR TITLE
feat: support fs map input for svg urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,24 @@ export default () => (
 
 // Returns URL pointing to https://svg.tscircuit.com
 ```
+
+#### Using an fsMap
+
+```ts
+import { createSvgUrl } from "@tscircuit/create-snippet-url"
+
+const svgUrl = createSvgUrl(
+  {
+    "index.tsx": "export default () => <board />",
+    "App.tsx": "export default () => <board />",
+  },
+  "schematic",
+  {
+    entrypoint: "App.tsx",
+    format: "png",
+    pngWidth: 1200,
+  },
+)
+
+// Returns a png URL that renders the provided fsMap on svg.tscircuit.com
+```

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,16 @@
 import { gzipSync, gunzipSync, strToU8, strFromU8 } from "fflate"
 import { base64ToBytes, bytesToBase64 } from "./bytesToBase64"
 
+export type FsMap = Record<string, string>
+
+export type CreateSvgUrlOptions = {
+  format?: "svg" | "png"
+  pngWidth?: number
+  pngHeight?: number
+  pngDensity?: number
+  entrypoint?: string
+}
+
 export function getCompressedBase64SnippetString(text: string) {
   // Compress the input string
   const compressedData = gzipSync(strToU8(text.trim()), {
@@ -28,11 +38,42 @@ export function getUncompressedSnippetString(
 }
 
 export function createSvgUrl(
-  tscircuitCode: string,
+  snippetOrFsMap: string | FsMap,
   svgType: "pcb" | "schematic" | "3d" | "pinout",
+  options: CreateSvgUrlOptions = {},
 ) {
-  const base64Data = getCompressedBase64SnippetString(tscircuitCode)
-  return `https://svg.tscircuit.com/?svg_type=${svgType}&code=${encodeURIComponent(base64Data)}`
+  const search = new URLSearchParams()
+  search.set("svg_type", svgType)
+
+  if (typeof snippetOrFsMap === "string") {
+    const base64Data = getCompressedBase64SnippetString(snippetOrFsMap)
+    search.set("code", base64Data)
+  } else if (snippetOrFsMap && typeof snippetOrFsMap === "object") {
+    const encodedFsMap = encodeFsMap(snippetOrFsMap)
+    search.set("fs_map", encodedFsMap)
+
+    if (options.entrypoint) {
+      search.set("entrypoint", options.entrypoint)
+    }
+  } else {
+    throw new Error("Invalid snippet or fsMap provided to createSvgUrl")
+  }
+
+  if (options.format) {
+    search.set("format", options.format)
+  }
+  if (options.pngWidth !== undefined) {
+    search.set("png_width", String(options.pngWidth))
+  }
+  if (options.pngHeight !== undefined) {
+    search.set("png_height", String(options.pngHeight))
+  }
+  if (options.pngDensity !== undefined) {
+    search.set("png_density", String(options.pngDensity))
+  }
+
+  const query = search.toString()
+  return `https://svg.tscircuit.com/?${query}`
 }
 
 export function createBrowserPreviewUrl(
@@ -56,4 +97,12 @@ export function createSnippetUrl(text: string, snippet_type?: string): string {
   const typeParam = snippet_type ? `&snippet_type=${snippet_type}` : ""
 
   return `https://tscircuit.com/editor?${typeParam}${getBase64PoundSnippetString(text)}`
+}
+
+function encodeFsMap(fsMap: FsMap) {
+  const json = JSON.stringify(fsMap)
+  const compressedData = gzipSync(strToU8(json), {
+    mtime: 1739063707691,
+  })
+  return bytesToBase64(compressedData)
 }

--- a/tests/test3-svg-url.test.ts
+++ b/tests/test3-svg-url.test.ts
@@ -32,8 +32,9 @@ test("create svg url using fs map", () => {
   const fsMapParam = parsed.searchParams.get("fs_map")
   expect(fsMapParam).not.toBeNull()
 
+  const encodedFsMap = Buffer.from(fsMapParam!, "base64")
   const decodedFsMap = JSON.parse(
-    strFromU8(gunzipSync(Buffer.from(fsMapParam!, "base64"))),
+    strFromU8(gunzipSync(Uint8Array.from(encodedFsMap))),
   )
 
   expect(decodedFsMap).toEqual({

--- a/tests/test3-svg-url.test.ts
+++ b/tests/test3-svg-url.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test"
 import { createSvgUrl } from "lib"
+import { gunzipSync, strFromU8 } from "fflate"
 
 test("create pcb svg url", () => {
   const url = createSvgUrl(
@@ -16,6 +17,70 @@ export default () => (
   expect(url).toMatchInlineSnapshot(
     `"https://svg.tscircuit.com/?svg_type=pcb&code=H4sIAJsBqGcAAy2NTQ7CIBhE9z3FhFW7KlWXhUO4ckuBClF%2BAp%2FRxHh30Xb3JvMyY185FYKxq3rcCf0AIdF3wLwkVQye3pATbOIhMDjrr472JJvUtGKrr5QKNlBR2ybcGNaUKBcfm89P%2FMAQVWjVeWKo2l3E%2B%2FhB1ssG429tHv%2Bfshu%2BlSYxzJYAAAA%3D"`,
   )
+})
+
+test("create svg url using fs map", () => {
+  const url = createSvgUrl(
+    {
+      "index.tsx": `export default () => (\n  <board />\n)`,
+    },
+    "pcb",
+  )
+
+  const parsed = new URL(url)
+  expect(parsed.searchParams.get("code")).toBeNull()
+  const fsMapParam = parsed.searchParams.get("fs_map")
+  expect(fsMapParam).not.toBeNull()
+
+  const decodedFsMap = JSON.parse(
+    strFromU8(gunzipSync(Buffer.from(fsMapParam!, "base64"))),
+  )
+
+  expect(decodedFsMap).toEqual({
+    "index.tsx": "export default () => (\n  <board />\n)",
+  })
+})
+
+test("fs map svg url passes entrypoint", () => {
+  const url = createSvgUrl(
+    {
+      "index.tsx": "export default () => null",
+      "App.tsx": "export default () => null",
+    },
+    "schematic",
+    { entrypoint: "App.tsx" },
+  )
+
+  const parsed = new URL(url)
+  expect(parsed.searchParams.get("entrypoint")).toBe("App.tsx")
+  expect(parsed.searchParams.get("fs_map")).not.toBeNull()
+  expect(parsed.searchParams.get("code")).toBeNull()
+})
+
+test("create svg url with png options", () => {
+  const url = createSvgUrl(
+    `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)
+`,
+    "pcb",
+    {
+      format: "png",
+      pngWidth: 800,
+      pngHeight: 600,
+      pngDensity: 2,
+    },
+  )
+
+  const parsed = new URL(url)
+  expect(parsed.searchParams.get("format")).toBe("png")
+  expect(parsed.searchParams.get("png_width")).toBe("800")
+  expect(parsed.searchParams.get("png_height")).toBe("600")
+  expect(parsed.searchParams.get("png_density")).toBe("2")
+  expect(parsed.searchParams.get("code")).not.toBeNull()
 })
 
 test("create pinout svg url", () => {


### PR DESCRIPTION
## Summary
- allow createSvgUrl to accept either raw code or an fsMap payload when building svg.tscircuit.com links
- add optional rendering settings such as format and PNG dimensions to createSvgUrl
- document fsMap usage and cover new behaviors with targeted tests

## Testing
- bun test tests/test3-svg-url.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e96a5a9e08832e9ba9ccf5f365c81e