### PR TITLE
feat: add schsim svg type

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -39,7 +39,7 @@ export function getUncompressedSnippetString(
 
 export function createSvgUrl(
   snippetOrFsMap: string | FsMap,
-  svgType: "pcb" | "schematic" | "3d" | "pinout",
+  svgType: "pcb" | "schematic" | "3d" | "pinout" | "schsim",
   options: CreateSvgUrlOptions = {},
 ) {
   const search = new URLSearchParams()

--- a/tests/test3-svg-url.test.ts
+++ b/tests/test3-svg-url.test.ts
@@ -100,3 +100,20 @@ export default () => (
     `"https://svg.tscircuit.com/?svg_type=pinout&code=H4sIAJsBqGcAAy2NTQ7CIBhE9z3FhFW7KlWXhUO4ckuBClF%2BAp%2FRxHh30Xb3JvMyY185FYKxq3rcCf0AIdF3wLwkVQye3pATbOIhMDjrr472JJvUtGKrr5QKNlBR2ybcGNaUKBcfm89P%2FMAQVWjVeWKo2l3E%2B%2FhB1ssG429tHv%2Bfshu%2BlSYxzJYAAAA%3D"`,
   )
 })
+
+test("create schsim svg url", () => {
+  const url = createSvgUrl(
+    `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)
+`,
+    "schsim",
+  )
+
+  expect(url).toMatchInlineSnapshot(
+    `"https://svg.tscircuit.com/?svg_type=schsim&code=H4sIAJsBqGcAAy2NTQ7CIBhE9z3FhFW7KlWXhUO4ckuBClF%2BAp%2FRxHh30Xb3JvMyY185FYKxq3rcCf0AIdF3wLwkVQye3pATbOIhMDjrr472JJvUtGKrr5QKNlBR2ybcGNaUKBcfm89P%2FMAQVWjVeWKo2l3E%2B%2FhB1ssG429tHv%2Bfshu%2BlSYxzJYAAAA%3D"`,
+  )
+})


### PR DESCRIPTION
This PR adds support for the schsim SVG type.                                                                                                          

 • The createSvgUrl function now accepts "schsim" as a valid svgType.                                                                                  
 • Added a test case to ensure the schsim type generates the correct URL.