### PR TITLE
feat: Add simulationExperimentId for schsim SVGs

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,6 +9,7 @@ export type CreateSvgUrlOptions = {
   pngHeight?: number
   pngDensity?: number
   entrypoint?: string
+  simulationExperimentId?: string
 }
 
 export function getCompressedBase64SnippetString(text: string) {
@@ -70,6 +71,9 @@ export function createSvgUrl(
   }
   if (options.pngDensity !== undefined) {
     search.set("png_density", String(options.pngDensity))
+  }
+  if (options.simulationExperimentId) {
+    search.set("simulation_experiment_id", options.simulationExperimentId)
   }
 
   const query = search.toString()

--- a/tests/test3-svg-url.test.ts
+++ b/tests/test3-svg-url.test.ts
@@ -117,3 +117,22 @@ export default () => (
     `"https://svg.tscircuit.com/?svg_type=schsim&code=H4sIAJsBqGcAAy2NTQ7CIBhE9z3FhFW7KlWXhUO4ckuBClF%2BAp%2FRxHh30Xb3JvMyY185FYKxq3rcCf0AIdF3wLwkVQye3pATbOIhMDjrr472JJvUtGKrr5QKNlBR2ybcGNaUKBcfm89P%2FMAQVWjVeWKo2l3E%2B%2FhB1ssG429tHv%2Bfshu%2BlSYxzJYAAAA%3D"`,
   )
 })
+
+test("create schsim svg url with simulation experiment id", () => {
+  const url = createSvgUrl(
+    `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)
+`,
+    "schsim",
+    {
+      simulationExperimentId: "my-exp-1",
+    },
+  )
+
+  const parsed = new URL(url)
+  expect(parsed.searchParams.get("simulation_experiment_id")).toBe("my-exp-1")
+})


### PR DESCRIPTION
Adds a simulationExperimentId option to createSvgUrl to support passing an experiment ID for   
schematic simulation SVGs. This new option adds the simulation_experiment_id query parameter to
the generated URL.                                                                             

Includes a new test case to verify the functionality.  