### PR TITLE
Fix createPngUrl to generate PNG URLs from svg.tscircuit.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,22 @@ const svgUrl = createSvgUrl(
 
 // Returns a png URL that renders the provided fsMap on svg.tscircuit.com
 ```
+
+### PNG URLs
+
+```ts
+import { createPngUrl } from "@tscircuit/create-snippet-url"
+
+const pngUrl = createPngUrl(
+  `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)
+`,
+  "pcb",
+)
+
+// Returns a png URL rendered by https://svg.tscircuit.com
+```

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -96,8 +96,7 @@ export function createPngUrl(
   tscircuitCode: string,
   view: "pcb" | "schematic" | "3d",
 ) {
-  const base64Data = getCompressedBase64SnippetString(tscircuitCode)
-  return `https://png.tscircuit.com/?view=${view}&code=${encodeURIComponent(base64Data)}`
+  return createSvgUrl(tscircuitCode, view, { format: "png" })
 }
 
 export function createSnippetUrl(text: string, snippet_type?: string): string {

--- a/tests/test3-svg-url.test.ts
+++ b/tests/test3-svg-url.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test"
-import { createSvgUrl } from "lib"
+import { createPngUrl, createSvgUrl } from "lib"
 import { gunzipSync, strFromU8 } from "fflate"
 
 test("create pcb svg url", () => {
@@ -81,6 +81,25 @@ export default () => (
   expect(parsed.searchParams.get("png_width")).toBe("800")
   expect(parsed.searchParams.get("png_height")).toBe("600")
   expect(parsed.searchParams.get("png_density")).toBe("2")
+  expect(parsed.searchParams.get("code")).not.toBeNull()
+})
+
+test("create png url uses svg.tscircuit.com", () => {
+  const url = createPngUrl(
+    `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)
+`,
+    "pcb",
+  )
+
+  const parsed = new URL(url)
+  expect(parsed.origin).toBe("https://svg.tscircuit.com")
+  expect(parsed.searchParams.get("svg_type")).toBe("pcb")
+  expect(parsed.searchParams.get("format")).toBe("png")
   expect(parsed.searchParams.get("code")).not.toBeNull()
 })
 


### PR DESCRIPTION
## Summary

This fixes `createPngUrl` so it generates PNG URLs through `https://svg.tscircuit.com/` instead of the legacy `png.tscircuit.com` host.

## Root Cause

`createPngUrl` was still building URLs against `png.tscircuit.com`, while PNG rendering now works through the SVG service using `format=png`.

## Changes

- route `createPngUrl` through `createSvgUrl(..., { format: "png" })`
- add a regression test that verifies the generated URL uses `svg.tscircuit.com`, preserves the requested view, and includes `format=png`
- document `createPngUrl` usage in the README

## Impact

- keeps PNG URL generation aligned with the current rendering service
- reduces divergence between the public PNG helper and the main SVG URL builder
- prevents regressions where `createPngUrl` points at the wrong host

## Validation

- `bun test`

## Verified URLs

- PCB: `https://svg.tscircuit.com/?svg_type=pcb&code=H4sIAJsBqGcAAy2NTQ7CIBhE9z3FhFW7KlWXhUO4ckuBClF%2BAp%2FRxHh30Xb3JvMyY185FYKxq3rcCf0AIdF3wLwkVQye3pATbOIhMDjrr472JJvUtGKrr5QKNlBR2ybcGNaUKBcfm89P%2FMAQVWjVeWKo2l3E%2B%2FhB1ssG429tHv%2Bfshu%2BlSYxzJYAAAA%3D&format=png`
- 3D: `https://svg.tscircuit.com/?svg_type=3d&code=H4sIAJsBqGcAAy2NTQ7CIBhE9z3FhFW7KlWXhUO4ckuBClF%2BAp%2FRxHh30Xb3JvMyY185FYKxq3rcCf0AIdF3wLwkVQye3pATbOIhMDjrr472JJvUtGKrr5QKNlBR2ybcGNaUKBcfm89P%2FMAQVWjVeWKo2l3E%2B%2FhB1ssG429tHv%2Bfshu%2BlSYxzJYAAAA%3D&format=png`
- Schematic: `https://svg.tscircuit.com/?svg_type=schematic&code=H4sIAJsBqGcAAy2NTQ7CIBhE9z3FhFW7KlWXhUO4ckuBClF%2BAp%2FRxHh30Xb3JvMyY185FYKxq3rcCf0AIdF3wLwkVQye3pATbOIhMDjrr472JJvUtGKrr5QKNlBR2ybcGNaUKBcfm89P%2FMAQVWjVeWKo2l3E%2B%2FhB1ssG429tHv%2Bfshu%2BlSYxzJYAAAA%3D&format=png`
